### PR TITLE
Add in-memory transaction accounting API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,12 @@
             </exclusions>
         </dependency>
 
+        <!-- Bean validation support -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
         <!-- Tomcat provided (WildFly already has servlet container) -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/example/demo/transactions/ApiError.java
+++ b/src/main/java/com/example/demo/transactions/ApiError.java
@@ -1,0 +1,44 @@
+package com.example.demo.transactions;
+
+import java.time.OffsetDateTime;
+import java.util.Map;
+
+public class ApiError {
+
+    private OffsetDateTime timestamp;
+    private String message;
+    private Map<String, String> details;
+
+    public ApiError() {
+    }
+
+    public ApiError(OffsetDateTime timestamp, String message, Map<String, String> details) {
+        this.timestamp = timestamp;
+        this.message = message;
+        this.details = details;
+    }
+
+    public OffsetDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(OffsetDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
+    public void setDetails(Map<String, String> details) {
+        this.details = details;
+    }
+}

--- a/src/main/java/com/example/demo/transactions/RestExceptionHandler.java
+++ b/src/main/java/com/example/demo/transactions/RestExceptionHandler.java
@@ -1,0 +1,45 @@
+package com.example.demo.transactions;
+
+import java.time.OffsetDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiError> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        Map<String, String> errors = new LinkedHashMap<>();
+        for (FieldError fieldError : ex.getBindingResult().getFieldErrors()) {
+            errors.put(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+        ApiError apiError = new ApiError(OffsetDateTime.now(), "Validation failed", errors);
+        return ResponseEntity.badRequest().body(apiError);
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiError> handleConstraintViolationException(ConstraintViolationException ex) {
+        Map<String, String> errors = new LinkedHashMap<>();
+        for (ConstraintViolation<?> violation : ex.getConstraintViolations()) {
+            errors.put(violation.getPropertyPath().toString(), violation.getMessage());
+        }
+        ApiError apiError = new ApiError(OffsetDateTime.now(), "Constraint violation", errors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiError);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ApiError> handleIllegalArgumentException(IllegalArgumentException ex) {
+        ApiError apiError = new ApiError(OffsetDateTime.now(), ex.getMessage(), Map.of());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(apiError);
+    }
+}

--- a/src/main/java/com/example/demo/transactions/Transaction.java
+++ b/src/main/java/com/example/demo/transactions/Transaction.java
@@ -1,0 +1,116 @@
+package com.example.demo.transactions;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+public class Transaction {
+    private Long id;
+    private Long userId;
+    private BigDecimal amount;
+    private TransactionType type;
+    private String category;
+    private String note;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate transactionDate;
+    private OffsetDateTime createdAt;
+    private OffsetDateTime updatedAt;
+
+    public Transaction() {
+    }
+
+    public Transaction(
+            Long id,
+            Long userId,
+            BigDecimal amount,
+            TransactionType type,
+            String category,
+            String note,
+            LocalDate transactionDate,
+            OffsetDateTime createdAt,
+            OffsetDateTime updatedAt) {
+        this.id = id;
+        this.userId = userId;
+        this.amount = amount;
+        this.type = type;
+        this.category = category;
+        this.note = note;
+        this.transactionDate = transactionDate;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public TransactionType getType() {
+        return type;
+    }
+
+    public void setType(TransactionType type) {
+        this.type = type;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+    public LocalDate getTransactionDate() {
+        return transactionDate;
+    }
+
+    public void setTransactionDate(LocalDate transactionDate) {
+        this.transactionDate = transactionDate;
+    }
+
+    public OffsetDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(OffsetDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public OffsetDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(OffsetDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/example/demo/transactions/TransactionController.java
+++ b/src/main/java/com/example/demo/transactions/TransactionController.java
@@ -1,0 +1,77 @@
+package com.example.demo.transactions;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/transactions")
+@Validated
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    public TransactionController(TransactionService transactionService) {
+        this.transactionService = transactionService;
+    }
+
+    @PostMapping
+    public ResponseEntity<Transaction> createTransaction(@Valid @RequestBody TransactionRequest request) {
+        Transaction created = transactionService.create(request);
+        URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(created.getId())
+                .toUri();
+        return ResponseEntity.created(location).body(created);
+    }
+
+    @GetMapping
+    public List<Transaction> listTransactions(
+            @RequestParam(required = false) Long userId,
+            @RequestParam(required = false) TransactionType type,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate fromDate,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate toDate) {
+        return transactionService.findAll(userId, type, fromDate, toDate);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Transaction> getTransaction(@PathVariable Long id) {
+        return transactionService.findById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Transaction> updateTransaction(
+            @PathVariable Long id,
+            @Valid @RequestBody TransactionRequest request) {
+        return transactionService.update(id, request)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTransaction(@PathVariable Long id) {
+        boolean deleted = transactionService.delete(id);
+        if (!deleted) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/demo/transactions/TransactionRequest.java
+++ b/src/main/java/com/example/demo/transactions/TransactionRequest.java
@@ -1,0 +1,83 @@
+package com.example.demo.transactions;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class TransactionRequest {
+
+    @NotNull(message = "userId is required")
+    private Long userId;
+
+    @NotNull(message = "amount is required")
+    @DecimalMin(value = "0.00", inclusive = false, message = "amount must be greater than zero")
+    private BigDecimal amount;
+
+    @NotNull(message = "type is required")
+    private TransactionType type;
+
+    @NotBlank(message = "category is required")
+    private String category;
+
+    private String note;
+
+    @NotNull(message = "transactionDate is required")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate transactionDate;
+
+    public TransactionRequest() {
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+
+    public TransactionType getType() {
+        return type;
+    }
+
+    public void setType(TransactionType type) {
+        this.type = type;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public String getNote() {
+        return note;
+    }
+
+    public void setNote(String note) {
+        this.note = note;
+    }
+
+    public LocalDate getTransactionDate() {
+        return transactionDate;
+    }
+
+    public void setTransactionDate(LocalDate transactionDate) {
+        this.transactionDate = transactionDate;
+    }
+}

--- a/src/main/java/com/example/demo/transactions/TransactionService.java
+++ b/src/main/java/com/example/demo/transactions/TransactionService.java
@@ -1,0 +1,81 @@
+package com.example.demo.transactions;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class TransactionService {
+
+    private final Map<Long, Transaction> transactions = new ConcurrentHashMap<>();
+    private final AtomicLong idSequence = new AtomicLong(1);
+
+    public Transaction create(TransactionRequest request) {
+        OffsetDateTime now = OffsetDateTime.now();
+        Transaction transaction = new Transaction(
+                idSequence.getAndIncrement(),
+                request.getUserId(),
+                request.getAmount(),
+                request.getType(),
+                request.getCategory(),
+                request.getNote(),
+                request.getTransactionDate(),
+                now,
+                now);
+        transactions.put(transaction.getId(), transaction);
+        return transaction;
+    }
+
+    public List<Transaction> findAll(Long userId, TransactionType type, LocalDate fromDate, LocalDate toDate) {
+        List<Transaction> filtered = new ArrayList<>();
+        for (Transaction transaction : transactions.values()) {
+            if (userId != null && !userId.equals(transaction.getUserId())) {
+                continue;
+            }
+            if (type != null && type != transaction.getType()) {
+                continue;
+            }
+            if (fromDate != null && transaction.getTransactionDate().isBefore(fromDate)) {
+                continue;
+            }
+            if (toDate != null && transaction.getTransactionDate().isAfter(toDate)) {
+                continue;
+            }
+            filtered.add(transaction);
+        }
+        filtered.sort(Comparator.comparing(Transaction::getTransactionDate).reversed()
+                .thenComparing(Transaction::getId, Comparator.reverseOrder()));
+        return filtered;
+    }
+
+    public Optional<Transaction> findById(Long id) {
+        return Optional.ofNullable(transactions.get(id));
+    }
+
+    public Optional<Transaction> update(Long id, TransactionRequest request) {
+        Transaction existing = transactions.get(id);
+        if (existing == null) {
+            return Optional.empty();
+        }
+        existing.setUserId(request.getUserId());
+        existing.setAmount(request.getAmount());
+        existing.setType(request.getType());
+        existing.setCategory(request.getCategory());
+        existing.setNote(request.getNote());
+        existing.setTransactionDate(request.getTransactionDate());
+        existing.setUpdatedAt(OffsetDateTime.now());
+        return Optional.of(existing);
+    }
+
+    public boolean delete(Long id) {
+        return transactions.remove(id) != null;
+    }
+}

--- a/src/main/java/com/example/demo/transactions/TransactionType.java
+++ b/src/main/java/com/example/demo/transactions/TransactionType.java
@@ -1,0 +1,6 @@
+package com.example.demo.transactions;
+
+public enum TransactionType {
+    INCOME,
+    EXPENSE
+}


### PR DESCRIPTION
## Summary
- add bean validation support to enable request validation on the new accounting endpoints
- implement an in-memory transaction domain, service, and REST controller for creating, listing, updating, and deleting entries
- provide structured error responses for validation failures

## Testing
- `mvn -q -DskipTests package` *(fails: Maven Central returned 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d654bcac908323b7f054925ca2262f